### PR TITLE
disable node integration for popup window

### DIFF
--- a/auth0-electron.js
+++ b/auth0-electron.js
@@ -7,7 +7,7 @@ window.electron = {};
 Auth0Lock._setOpenWindowFn(function(url, name, options) {
   let listeners = [];
 
-  const win = new BrowserWindow({show: false});
+  const win = new BrowserWindow({show: false, webPreferences: { nodeIntegration: false }});
   win.loadURL(url);
   win.show();
 


### PR DESCRIPTION
(facebook require enabled cookie), fix https://github.com/auth0/docs/issues/993