### PR TITLE
Bumping electron-prebuilt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/auth0/auth0-electron#readme",
   "devDependencies": {
-    "electron-prebuilt": "^0.36.7"
+    "electron-prebuilt": "^1.2.8"
   }
 }


### PR DESCRIPTION
Fixes issue on Windows where all login attempts fail due to invalid callback URL.